### PR TITLE
Port missing logic and get unit tests working

### DIFF
--- a/notebook_shim/nbserver.py
+++ b/notebook_shim/nbserver.py
@@ -115,6 +115,21 @@ def _link_jupyter_server_extension(serverapp):
     config_dirs = jupyter_paths + [serverapp.config_dir]
     nbserver_extensions = get_nbserver_extensions(config_dirs)
 
+    # Link all extensions found in the old locations for
+    # notebook server extensions.
+    for name, enabled in nbserver_extensions.items():
+        # If the extension is already enabled in the manager, i.e.
+        # because it was discovered already by Jupyter Server
+        # through its jupyter_server_config, then don't re-enable here.
+        if name not in manager.extensions:
+            successful = manager.add_extension(name, enabled=enabled)
+            if successful:
+                logger.info(
+                    "{name} | extension was found and enabled by notebook_shim. "
+                    "Consider moving the extension to Jupyter Server's "
+                    "extension paths.".format(name=name)
+                )
+                manager.link_extension(name)
 
 def _load_jupyter_server_extension(serverapp):
     # Patch the config service manager to find the

--- a/notebook_shim/tests/mockextension.py
+++ b/notebook_shim/tests/mockextension.py
@@ -11,7 +11,7 @@ from notebook_shim import shim
 def _jupyter_server_extension_points():
     return [
         {
-            "module": "notebook_shim.tests.shim.mockextension",
+            "module": "notebook_shim.tests.mockextension",
             "app": MockExtensionApp
         }
     ]

--- a/notebook_shim/tests/test_extension.py
+++ b/notebook_shim/tests/test_extension.py
@@ -45,7 +45,7 @@ def jp_server_config():
         "ServerApp": {
             "jpserver_extensions": {
                 "notebook_shim": True,
-                "notebook_shim.tests.shim.mockextension": True
+                "notebook_shim.tests.mockextension": True
             }
         }
     }


### PR DESCRIPTION
I missed some key logic needed to load extensions that are configured in the classic server extension config paths. Added it here and fixed the unit tests.