### PR TITLE
Automated Changelog Entry for 0.1.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,27 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0
+
+([Full Changelog](https://github.com/jupyterlab/notebook_shim/compare/first-commit...5b433fa298f741c7d71c9a3e7e85f17b2207300f))
+
+### Enhancements made
+
+- [WIP] Move over initial shim logic [#1](https://github.com/jupyterlab/notebook_shim/pull/1) ([@Zsailer](https://github.com/Zsailer))
+
+### Bugs fixed
+
+- Port missing logic and get unit tests working [#5](https://github.com/jupyterlab/notebook_shim/pull/5) ([@Zsailer](https://github.com/Zsailer))
+
+### Maintenance and upkeep improvements
+
+- Add a test workflow on CI [#4](https://github.com/jupyterlab/notebook_shim/pull/4) ([@jtpio](https://github.com/jtpio))
+- Add `check-release` workflow on CI [#3](https://github.com/jupyterlab/notebook_shim/pull/3) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/notebook_shim/graphs/contributors?from=2022-01-19&to=2022-02-10&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fnotebook_shim+involves%3Ajtpio+updated%3A2022-01-19..2022-02-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fnotebook_shim+involves%3Awelcome+updated%3A2022-01-19..2022-02-10&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fnotebook_shim+involves%3AZsailer+updated%3A2022-01-19..2022-02-10&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/notebook_shim  |
| Branch  | main  |
| Version Spec | 0.1.0 |
| Since | first-commit |